### PR TITLE
Add secrets support to GKE apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-# 0.5.0 (Unreleased)
-* Moving secrets to Google Secrets Manager. 
-* Configuring external-secrets.io secret store to sync k8s secrets with Google Secrets Manager.
-* Configuring application pod with a kubernetes service account.
+# 0.5.0 (Mar 30, 2023)
+* Moved connection from `cluster` to `cluster-namespace`.
+* Moved secrets to Google Secrets Manager. 
+* Configured external-secrets.io secret store to sync k8s secrets with Google Secrets Manager.
+* Configured application pod with a kubernetes service account.
 * Kubernetes service account has impersonation access to GCP.
 
 # 0.4.9 (Mar 25, 2023)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.5.0 (Unreleased)
+* Moving secrets to Google Secrets Manager. 
+* Configuring external-secrets.io secret store to sync k8s secrets with Google Secrets Manager.
+* Configuring application pod with a kubernetes service account.
+* Kubernetes service account has impersonation access to GCP.
+
 # 0.4.9 (Mar 25, 2023)
 * Replace `_` in Kubernetes secret name with `-` to make it valid.
 * Add kubernetes recommended labels. (https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/)

--- a/app.tf
+++ b/app.tf
@@ -12,6 +12,8 @@ locals {
 
 locals {
   app_metadata = tomap({
-    // Inject app metadata into capabilities here (e.g. security_group_name, role_name)
+    // Inject app metadata into capabilities here (e.g. service_account_id)
+    service_account_id    = google_service_account.app.id
+    service_account_email = google_service_account.app.email
   })
 }

--- a/app.tf
+++ b/app.tf
@@ -5,7 +5,7 @@ data "ns_app_env" "this" {
 }
 
 locals {
-  app_namespace = "default"
+  app_namespace = local.kubernetes_namespace
   app_name      = data.ns_workspace.this.block_name
   app_version   = coalesce(data.ns_app_env.this.version, "latest")
 }

--- a/cluster.tf
+++ b/cluster.tf
@@ -8,6 +8,7 @@ locals {
   cluster_name           = data.ns_connection.cluster_namespace.outputs.cluster_name
   cluster_endpoint       = data.ns_connection.cluster_namespace.outputs.cluster_endpoint
   cluster_ca_certificate = data.ns_connection.cluster_namespace.outputs.cluster_ca_certificate
+  kubernetes_namespace   = data.ns_connection.cluster_namespace.outputs.kubernetes_namespace
 }
 
 // See https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config#example-usage-configure-kubernetes-provider-with-oauth2-access-token

--- a/cluster.tf
+++ b/cluster.tf
@@ -1,10 +1,20 @@
-data "ns_connection" "cluster" {
-  name     = "cluster"
-  contract = "cluster/gcp/k8s:gke"
+data "ns_connection" "cluster_namespace" {
+  name     = "cluster-namespace"
+  contract = "cluster-namespace/gcp/k8s:gke"
 }
 
 locals {
   service_image          = data.google_container_registry_image.this.image_url
-  cluster_endpoint       = data.ns_connection.cluster.outputs.cluster_endpoint
-  cluster_ca_certificate = data.ns_connection.cluster.outputs.cluster_ca_certificate
+  cluster_name           = data.ns_connection.cluster_namespace.outputs.cluster_name
+  cluster_endpoint       = data.ns_connection.cluster_namespace.outputs.cluster_endpoint
+  cluster_ca_certificate = data.ns_connection.cluster_namespace.outputs.cluster_ca_certificate
+}
+
+// See https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config#example-usage-configure-kubernetes-provider-with-oauth2-access-token
+data "google_client_config" "provider" {}
+
+provider "kubernetes" {
+  host                   = "https://${local.cluster_endpoint}"
+  token                  = data.google_client_config.provider.access_token
+  cluster_ca_certificate = base64decode(local.cluster_ca_certificate)
 }

--- a/deployer.tf
+++ b/deployer.tf
@@ -1,0 +1,19 @@
+locals {
+  truncated_len = min(length(local.block_ref), 28 - length("deployer--12345"))
+  deployer_name = "deployer-${substr(local.block_ref, 0, local.truncated_len)}-${random_string.resource_suffix.result}"
+}
+
+resource "google_service_account" "deployer" {
+  account_id   = local.deployer_name
+  display_name = "Deployer for ${local.block_name}"
+}
+
+resource "google_service_account_key" "deployer" {
+  service_account_id = google_service_account.deployer.account_id
+}
+
+resource "google_project_iam_member" "deployer_developer_access" {
+  project = local.project_id
+  role    = "roles/container.developer"
+  member  = "serviceAccount:${google_service_account.deployer.email}"
+}

--- a/deployment.tf
+++ b/deployment.tf
@@ -57,15 +57,15 @@ resource "kubernetes_deployment" "this" {
           }
 
           dynamic "env" {
-            for_each = local.secret_refs
+            for_each = local.secret_keys
 
             content {
-              name = env.key
+              name = env.value
 
               value_from {
                 secret_key_ref {
-                  name = env.value
-                  key  = "value"
+                  name = "${local.resource_name}-gsm-secrets"
+                  key  = env.value
                 }
               }
             }

--- a/deployment.tf
+++ b/deployment.tf
@@ -25,7 +25,8 @@ resource "kubernetes_deployment" "this" {
       }
 
       spec {
-        restart_policy = "Always"
+        restart_policy       = "Always"
+        service_account_name = kubernetes_service_account.app.metadata[0].name
 
         container {
           name  = local.main_container_name

--- a/gcp.tf
+++ b/gcp.tf
@@ -1,0 +1,5 @@
+data "google_compute_zones" "available" {}
+
+locals {
+  project_id = data.google_compute_zones.available.project
+}

--- a/gcp.tf
+++ b/gcp.tf
@@ -1,5 +1,7 @@
-data "google_compute_zones" "available" {}
+data "google_client_config" "this" {}
 
 locals {
-  project_id = data.google_compute_zones.available.project
+  region     = data.google_client_config.this.region
+  zone       = data.google_client_config.this.zone
+  project_id = data.google_client_config.this.project
 }

--- a/kubernetes.tf
+++ b/kubernetes.tf
@@ -1,3 +1,4 @@
+// See https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config#example-usage-configure-kubernetes-provider-with-oauth2-access-token
 data "google_client_config" "provider" {}
 
 provider "kubernetes" {

--- a/kubernetes.tf
+++ b/kubernetes.tf
@@ -1,8 +1,0 @@
-// See https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config#example-usage-configure-kubernetes-provider-with-oauth2-access-token
-data "google_client_config" "provider" {}
-
-provider "kubernetes" {
-  host                   = "https://${local.cluster_endpoint}"
-  token                  = data.google_client_config.provider.access_token
-  cluster_ca_certificate = base64decode(local.cluster_ca_certificate)
-}

--- a/outputs.tf
+++ b/outputs.tf
@@ -29,6 +29,17 @@ output "image_pusher" {
   sensitive = true
 }
 
+output "deployer" {
+  value = {
+    email       = try(google_service_account.deployer.email, "")
+    private_key = try(google_service_account_key.deployer.private_key, "")
+  }
+
+  description = "object({ email: string, private_key: string }) ||| A GCP service account with explicit privilege to deploy this GKE service to its cluster."
+  sensitive   = true
+}
+
+
 output "main_container_name" {
   value       = local.main_container_name
   description = "string ||| The name of the container definition for the main service container"

--- a/secrets.tf
+++ b/secrets.tf
@@ -45,7 +45,7 @@ resource "kubernetes_manifest" "gsm_secret_store" {
               clusterLocation = local.region
               clusterName     = local.cluster_name
               serviceAccountRef = {
-                name = google_service_account.app.name
+                name = kubernetes_service_account.app.metadata.0.name
               }
             }
           }

--- a/secrets.tf
+++ b/secrets.tf
@@ -42,7 +42,7 @@ resource "kubernetes_manifest" "gsm_secret_store" {
 
           auth = {
             workloadIdentity = {
-              clusterLocation = "" // TODO: Add cluster location
+              clusterLocation = local.region
               clusterName     = local.cluster_name
               serviceAccountRef = {
                 name = google_service_account.app.name

--- a/secrets.tf
+++ b/secrets.tf
@@ -30,8 +30,9 @@ resource "kubernetes_manifest" "gsm_secret_store" {
     kind       = "SecretStore"
 
     metadata = {
-      name   = local.app_secret_store_name
-      labels = local.labels
+      namespace = local.app_namespace
+      name      = local.app_secret_store_name
+      labels    = local.labels
     }
 
     spec = {
@@ -65,8 +66,9 @@ resource "kubernetes_manifest" "secrets_from_gsm" {
     kind       = "ExternalSecret"
 
     metadata = {
-      name   = "${local.resource_name}-gsm-secrets"
-      labels = local.labels
+      namespace = local.app_namespace
+      name      = "${local.resource_name}-gsm-secrets"
+      labels    = local.labels
     }
 
     spec = {

--- a/secrets.tf
+++ b/secrets.tf
@@ -1,6 +1,6 @@
 locals {
-  // secret_refs is prepared in the form [{ name = "", valueFrom = "<arn>" }, ...] for injection into ECS services
-  secret_refs = { for key in local.secret_keys : key => google_secret_manager_secret.app_secret[key].id }
+  // Valid metadata name: [a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*
+  app_secret_store_name = "${local.resource_name}-gsm-secrets"
 }
 
 resource "google_secret_manager_secret" "app_secret" {
@@ -22,17 +22,67 @@ resource "google_secret_manager_secret_version" "app_secret" {
   secret_data = local.all_secrets[each.value]
 }
 
-resource "kubernetes_secret" "app_secret" {
-  for_each = local.secret_keys
+// The secret store defines "how" to access google secrets manager
+// This secret store is only reponsible for establishing authentication config
+resource "kubernetes_manifest" "gsm_secret_store" {
+  manifest = {
+    apiVersion = "external-secrets.io/v1beta1"
+    kind       = "SecretStore"
 
-  metadata {
-    // Valid metadata name: [a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*
-    name   = lower(replace("${local.resource_name}_${each.value}", "/[^a-zA-Z0-9]/", "-"))
-    labels = local.labels
+    metadata = {
+      name   = local.app_secret_store_name
+      labels = local.labels
+    }
+
+    spec = {
+      provider = {
+        gcpsm = {
+          projectID = local.project_id
+
+          auth = {
+            workloadIdentity = {
+              clusterLocation = "" // TODO: Add cluster location
+              clusterName     = local.cluster_name
+              serviceAccountRef = {
+                name = google_service_account.app.name
+              }
+            }
+          }
+        }
+      }
+    }
   }
+}
 
-  type = "ExternalSecret"
-  data = {
-    value = local.all_secrets[each.value]
+// The `ExternalSecret` resource creates a single k8s Secret
+// with all secrets from capabilities and `secrets` var for this application pod
+// Each `key` in this secret maps directly to an env var to inject into the app pod
+resource "kubernetes_manifest" "secrets_from_gsm" {
+  depends_on = [kubernetes_manifest.gsm_secret_store]
+
+  manifest = {
+    apiVersion = "external-secrets.io/v1beta1"
+    kind       = "ExternalSecret"
+
+    metadata = {
+      name   = "${local.resource_name}-gsm-secrets"
+      labels = local.labels
+    }
+
+    spec = {
+      secretStoreRef = {
+        kind = "SecretStore"
+        name = local.app_secret_store_name
+      }
+      target = {
+        name = "${local.resource_name}-gsm-secrets"
+      }
+      data = [for key in local.secret_keys : {
+        secretKey = key
+        remoteRef = {
+          key = google_secret_manager_secret.app_secret[key].name
+        }
+      }]
+    }
   }
 }

--- a/secrets.tf
+++ b/secrets.tf
@@ -82,7 +82,7 @@ resource "kubernetes_manifest" "secrets_from_gsm" {
       data = [for key in local.secret_keys : {
         secretKey = key
         remoteRef = {
-          key = google_secret_manager_secret.app_secret[key].name
+          key = google_secret_manager_secret.app_secret[key].secret_id
         }
       }]
     }

--- a/service-account.tf
+++ b/service-account.tf
@@ -1,0 +1,26 @@
+resource "google_service_account" "app" {
+  account_id   = local.resource_name
+  display_name = "Service Account for Nullstone App ${local.app_name}"
+}
+
+resource "kubernetes_service_account" "app" {
+  metadata {
+    namespace = local.app_namespace
+    name      = local.app_name
+    labels    = local.app_labels
+
+    annotations = {
+      // This indicates which GCP service account this kubernetes service account can impersonate
+      "iam.gke.io/gcp-service-account" = google_service_account.app.email
+    }
+  }
+
+  automount_service_account_token = true
+}
+
+// This allows the kubernetes service account <app-namespace>/<app-name> to impersonate a workload identity
+resource "google_project_iam_member" "app_workload_identity" {
+  role    = "roles/iam.workloadIdentityUser"
+  member  = "serviceAccount:${local.project_id}.svc.id.goog[${local.app_namespace}/${local.app_name}]"
+  project = local.project_id
+}

--- a/service-account.tf
+++ b/service-account.tf
@@ -23,7 +23,12 @@ resource "google_service_account_iam_member" "app_workload_identity" {
   service_account_id = google_service_account.app.name
   role               = "roles/iam.workloadIdentityUser"
   member             = "serviceAccount:${local.project_id}.svc.id.goog[${local.app_namespace}/${local.app_name}]"
-  project            = local.project_id
+}
+
+resource "google_service_account_iam_member" "app_generate_token" {
+  service_account_id = google_service_account.app.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${local.project_id}.svc.id.goog[${local.app_namespace}/${local.app_name}]"
 }
 
 // See https://cloud.google.com/kubernetes-engine/docs/tutorials/workload-identity-secrets


### PR DESCRIPTION
This adds proper secrets support to GKE apps.
- Secrets are stored, encrypted, and secured using Google Secrets Manager (GSM).
- A Kubernetes secret is synchronized from GSM.
- The pod references the kubernetes secret to inject the secret as an env var on boot.

To accomplish this, the app module relies on a `cluster-namespace/gcp/k8s:gke` instead of `cluster/gcp/k8s:gke`.
The cluster namespace installs the external-secrets.io operator.
The new CRDs (`SecretStore` and `ExternalSecret`) are added in this module to synchronize k8s secrets with GSM.