### PR TITLE
Internal network port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.5.1 (Apr 19, 2023)
+* Added `ClusterIP` `Service` that exposes `var.port` to the cluster.
+* Added `service_port` and `service_name` to `app_metadata` so that capabilities know which port is exposed to the cluster.
+
 # 0.5.0 (Mar 30, 2023)
 * Moved connection from `cluster` to `cluster-namespace`.
 * Moved secrets to Google Secrets Manager. 

--- a/app.tf
+++ b/app.tf
@@ -15,6 +15,7 @@ locals {
     // Inject app metadata into capabilities here (e.g. service_account_id)
     service_account_id    = google_service_account.app.id
     service_account_email = google_service_account.app.email
+    service_name          = kubernetes_service.this.metadata[0].name
     service_port          = var.port
   })
 }

--- a/app.tf
+++ b/app.tf
@@ -15,5 +15,6 @@ locals {
     // Inject app metadata into capabilities here (e.g. service_account_id)
     service_account_id    = google_service_account.app.id
     service_account_email = google_service_account.app.email
+    service_port          = var.port
   })
 }

--- a/deployment.tf
+++ b/deployment.tf
@@ -16,7 +16,7 @@ resource "kubernetes_deployment" "this" {
     replicas = var.replicas
 
     selector {
-      match_labels = local.app_labels
+      match_labels = local.match_labels
     }
 
     template {

--- a/nullstone.tf
+++ b/nullstone.tf
@@ -23,7 +23,12 @@ locals {
   block_ref     = data.ns_workspace.this.block_ref
   resource_name = "${local.block_ref}-${random_string.resource_suffix.result}"
 
-  labels = {
+  match_labels = {
+    "nullstone.io/stack"     = data.ns_workspace.this.stack_name
+    "nullstone.io/block-ref" = data.ns_workspace.this.block_ref
+    "nullstone.io/env"       = data.ns_workspace.this.env_name
+  }
+  labels = merge({
     // k8s-recommended labels
     "app.kubernetes.io/name"       = local.block_name
     "app.kubernetes.io/version"    = local.app_version
@@ -31,12 +36,9 @@ locals {
     "app.kubernetes.io/part-of"    = data.ns_workspace.this.stack_name
     "app.kubernetes.io/managed-by" = "nullstone"
     // nullstone labels
-    "nullstone.io/stack" = data.ns_workspace.this.stack_name
     "nullstone.io/block" = data.ns_workspace.this.block_name
-    "nullstone.io/env"   = data.ns_workspace.this.env_name
-    "nullstone.io/ref"   = data.ns_workspace.this.block_ref
-  }
-  app_labels = {
+  }, local.match_labels)
+  app_labels = merge({
     // k8s-recommended labels
     "app.kubernetes.io/name"       = local.block_name
     "app.kubernetes.io/version"    = local.app_version
@@ -44,9 +46,6 @@ locals {
     "app.kubernetes.io/part-of"    = data.ns_workspace.this.stack_name
     "app.kubernetes.io/managed-by" = "nullstone"
     // nullstone labels
-    "nullstone.io/stack" = data.ns_workspace.this.stack_name
     "nullstone.io/app"   = data.ns_workspace.this.block_name
-    "nullstone.io/env"   = data.ns_workspace.this.env_name
-    "nullstone.io/ref"   = data.ns_workspace.this.block_ref
-  }
+  }, local.match_labels)
 }

--- a/service.tf
+++ b/service.tf
@@ -13,7 +13,8 @@ resource "kubernetes_service" "this" {
     }
 
     port {
-      port = var.port
+      port        = var.port
+      target_port = var.port
     }
   }
 }

--- a/service.tf
+++ b/service.tf
@@ -1,0 +1,19 @@
+resource "kubernetes_service" "this" {
+  metadata {
+    name      = local.app_name
+    namespace = local.app_namespace
+    labels    = local.app_labels
+  }
+
+  spec {
+    type = "ClusterIP"
+
+    selector = {
+      match_labels = local.match_labels
+    }
+
+    port {
+      port = var.port
+    }
+  }
+}


### PR DESCRIPTION
This exposes the pod's main container to the cluster via `var.port`.
The Kubernetes `Service` info is injected into capabilities via `var.app_metadata["service_name"]` and `var.app_metadata["service_port"]`.