### PR TITLE
Add GCPBackendPolicy for backend timeout, draining, affinity, and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ Additionally, a `Load Balancer` allows you to split traffic between more than 1 
 Logs are automatically emitted to AWS Cloudwatch Log Group: `/<task-name>`.
 To access through the Nullstone CLI, use `nullstone logs` CLI command. (See [`logs`](https://docs.nullstone.io/getting-started/cli/docs.html#logs) for more information)
 
+## Backend Policy
+
+This module creates a `GCPBackendPolicy` for the Service. The `backend_policy` variable controls:
+
+- **Timeout** – Backend request timeout in seconds (default: 30s).
+- **Connection draining** – Graceful draining timeout for removed backends.
+- **Session affinity** – Sticky sessions by type (`NONE`, `CLIENT_IP`, `GENERATED_COOKIE`, etc.) with optional cookie TTL.
+- **Access logging** – Whether to log requests and at what sample rate (enabled by default to preserve GKE defaults).
+
+See [Configure Gateway resources using Policies](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/configure-gateway-resources) for full details.
+
 ## Secrets
 
 Nullstone automatically injects secrets into your GKE Service through environment variables.

--- a/service.tf
+++ b/service.tf
@@ -37,3 +37,47 @@ resource "kubernetes_service_v1" "this" {
     }
   }
 }
+
+resource "kubernetes_manifest" "backend_policy" {
+  count = local.has_service ? 1 : 0
+
+  manifest = {
+    apiVersion = "networking.gke.io/v1"
+    kind       = "GCPBackendPolicy"
+
+    metadata = {
+      name      = local.service_name
+      namespace = local.app_namespace
+      labels    = local.app_labels
+    }
+
+    spec = {
+      targetRef = {
+        group = ""
+        kind  = "Service"
+        name  = local.service_name
+      }
+
+      default = merge(
+        {
+          timeoutSec = var.backend_policy.timeout_sec
+          logging = {
+            enabled    = var.backend_policy.logging.enabled
+            sampleRate = var.backend_policy.logging.sample_rate
+          }
+        },
+        var.backend_policy.connection_draining != null ? {
+          connectionDraining = {
+            drainingTimeoutSec = var.backend_policy.connection_draining.timeout_sec
+          }
+        } : {},
+        var.backend_policy.session_affinity != null ? {
+          sessionAffinity = {
+            type         = var.backend_policy.session_affinity.type
+            cookieTtlSec = var.backend_policy.session_affinity.cookie_ttl_sec
+          }
+        } : {},
+      )
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -56,6 +56,25 @@ Specify 0 to disable network connectivity to this app.
 EOF
 }
 
+variable "backend_policy" {
+  type = object({
+    timeout_sec = optional(number, 30)
+    connection_draining = optional(object({
+      timeout_sec = optional(number, 0)
+    }))
+    session_affinity = optional(object({
+      type           = optional(string, "NONE")
+      cookie_ttl_sec = optional(number, 0)
+    }))
+    logging = optional(object({
+      enabled     = optional(bool, true)
+      sample_rate = optional(number, 1000000)
+    }), { enabled = true })
+  })
+  default     = {}
+  description = "GCP backend policy configuration for the load balancer. Controls timeout, connection draining, session affinity, and access logging."
+}
+
 variable "image_url" {
   type    = string
   default = ""


### PR DESCRIPTION
## Summary
- Adds a `backend_policy` variable to configure GCPBackendPolicy on the Service
- Supports timeout, connection draining, session affinity, and access logging
- Logging is enabled by default to preserve GKE default behavior

Follows up on nullstone-modules/gcp-gke-dedicated-load-balancer#4 – only one GCPBackendPolicy per Service is allowed, so it belongs in gcp-gke-service rather than in a load balancer capability.

## Not yet included
The following GCPBackendPolicy fields are skipped for now since they require more careful consideration:
- `securityPolicy` – Cloud Armor backend security policy
- `iap` – Identity-Aware Proxy (OAuth2 client secret + client ID)
- `maxRatePerEndpoint` – traffic-based autoscaling / capacity-based load balancing